### PR TITLE
Fix typo in plugin download call

### DIFF
--- a/Core/Installer/Lib/PluginDownload.php
+++ b/Core/Installer/Lib/PluginDownload.php
@@ -41,7 +41,7 @@ class PluginDownload {
  * @param type $plugin
  */
 	public static function download($plugin) {
-		self::_fileDownloadn($plugin);
+                self::_fileDownload($plugin);
 	}
 
 	protected static function _fileDownload($plugin) {


### PR DESCRIPTION
## Summary
- correct method call in `PluginDownload::download`

## Testing
- `Console/cake test app AllTests --stderr` *(fails: php not found)*