### PR TITLE
Fix typo in redirect comment

### DIFF
--- a/Controller/AppController.php
+++ b/Controller/AppController.php
@@ -411,8 +411,8 @@
 			return 'Infinitas.last_page.' . $this->request->here;
 		}
 
-		/**
-		 * @brief save a maker for a later redirect
+               /**
+                * @brief save a marker for a later redirect
 		 *
 		 * @access public
 		 *


### PR DESCRIPTION
## Summary
- fix comment describing redirect marker

## Testing
- `Console/cake test app AllTests --stderr` *(fails: php not found)*