### PR TITLE
Improve module cache handling and setup

### DIFF
--- a/.codex/setup.sh
+++ b/.codex/setup.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+sudo apt-get update
+sudo DEBIAN_FRONTEND=noninteractive apt-get -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" upgrade
+sudo apt-get -q -y install git autoconf automake make libtool php5-dev php5-mysql php5-cli php5-xdebug php5-fpm php-apc htop iotop gettext
+

--- a/Core/Modules/View/Elements/cache_config.ctp
+++ b/Core/Modules/View/Elements/cache_config.ctp
@@ -1,5 +1,5 @@
 <?php
-echo $this->Form->input('ModuleConfig.diable_cache', array(
+echo $this->Form->input('ModuleConfig.disable_cache', array(
 	'type' => 'checkbox',
 	'label' => __d('modules', 'Dont cache this module'),
 	'default' => 0

--- a/Core/Modules/View/Helper/ModuleLoaderHelper.php
+++ b/Core/Modules/View/Helper/ModuleLoaderHelper.php
@@ -179,28 +179,28 @@ class ModuleLoaderHelper extends InfinitasHelper {
 			return false;
 		}
 
-		$p = array_merge(array(
-			'diable_cache' => false,
-			'cache' => true
-		), $params);
-		if ($p['disable_cache'] == true || $p['cache'] == false) {
-			var_dump('no cache');
-			return false;
-		}
-		$cache = array(
-			'cache_key' => $params['_module_id'],
-			'cache_config' => $plugin
-		);
+               $p = array_merge(array(
+                       'disable_cache' => false,
+                       'cache' => true
+               ), $params);
+               if ($p['disable_cache'] == true || $p['cache'] == false) {
+                       return false;
+               }
+               $cache = array(
+                       'config' => !empty($params['cache_config']) ? $params['cache_config'] : $plugin,
+                       'key' => !empty($params['cache_key']) ? $params['cache_key'] : null
+               );
 
-		if (is_array($params['cache'])) {
-			$cache = array_merge($cache, $params['cache']);
-		}
+               if (is_array($params['cache'])) {
+                       $cache = array_merge($cache, $params['cache']);
+               }
 
-		return array(
-			'key' => $cache['cache_key'],
-			'config' => $cache['config']
-		);
-	}
+               if (empty($cache['key'])) {
+                       return false;
+               }
+
+               return $cache;
+       }
 
 /**
  * Load the config for a module if available
@@ -320,7 +320,7 @@ class ModuleLoaderHelper extends InfinitasHelper {
 			}
 		}
 
-		$title = ($module['Module']['show_heading']) ?  : false;
+               $title = !empty($module['Module']['show_heading']) ? $module['Module']['name'] : false;
 		$content = (!empty($module['Module']['content'])) ? $module['Module']['content'] : false;
 
 		return array(

--- a/Core/Routes/Routing/InfinitasRouter.php
+++ b/Core/Routes/Routing/InfinitasRouter.php
@@ -44,14 +44,9 @@ class InfinitasRouter extends Router {
  * @return void
  */
 	public static function connect($route, $defaults = array(), $options = array()) {
-		if (empty($options['routeClass'])) {
-			$options['routeClass'] = 'InfinitasRoute';
-		} else {
-			if ($options['routeClass'] != 'PluginShortRoute') {
-				var_dump($options);
-				exit;
-			}
-		}
+               if (empty($options['routeClass'])) {
+                       $options['routeClass'] = 'InfinitasRoute';
+               }
 
 		parent::connect($route, $defaults, $options);
 	}


### PR DESCRIPTION
## Summary
- add Codex setup script installing PHP packages
- fix caching option names and validation in ModuleLoaderHelper
- correct `disable_cache` field in cache_config template

## Testing
- `Console/cake test app AllTests --stderr` *(fails: `php: not found`)*